### PR TITLE
Order dllReferences in assembly dependency order

### DIFF
--- a/build.txt
+++ b/build.txt
@@ -1,4 +1,5 @@
 displayName = assemblytest
 author = saschahi
-dllReferences = TwitchLib.Client, TwitchLib.Client.Enums, TwitchLib.Client.Models, TwitchLib.Communication, Microsoft.Extensions.Logging.Abstractions
+dllReferences = TwitchLib.Client.Enums, TwitchLib.Client.Models, TwitchLib.Client, TwitchLib.Communication, Microsoft.Extensions.Logging.Abstractions
 version = 0.1
+includePDB = true


### PR DESCRIPTION
tModLoader's `AssemblyManager` uses `Mono.Cecil` to encapsulate references. It loops through `dllReferences` in the order they're declared in the build folder. In order to encapsulate `TwitchLib.Client`, `TwitchLib.Client.Enums` needs to be processed first.